### PR TITLE
:unsigned-byte attribute type support

### DIFF
--- a/src/vao/vao.lisp
+++ b/src/vao/vao.lisp
@@ -28,7 +28,7 @@ unknown."))
 
 (defmethod attribute-size ((attr symbol))
   (ecase attr
-    (:byte 1)
+    ((:byte :unsigned-byte) 1)
     ((:short :half-float) 2)
     ((:float :int :unsigned-int) 4)
     (:double 8)))


### PR DESCRIPTION
Having this type is very useful for colors, e.g. (color :unsigned-byte
4 :out-type :float).
