### PR TITLE
Added the ability to transform lisp uniform symbols into GLSL camel-c…

### DIFF
--- a/src/shader-dict/macros.lisp
+++ b/src/shader-dict/macros.lisp
@@ -59,7 +59,7 @@ the source is a list.  In this case, `KEY` is the car of that list,
 
  ;; DEFDICT
 
-(defmacro defdict (name (&key shader-path) &body options)
+(defmacro defdict (name (&key shader-path (uniform-style :underscore)) &body options)
   (let ((shaders) (programs))
     (loop for option in options
           do (alexandria:switch ((car option) :test 'equalp
@@ -75,6 +75,7 @@ the source is a list.  In this case, `KEY` is the car of that list,
                             options
                           (push `(make-instance 'program-source
                                    :name ',name
+                                   :uniform-style ',uniform-style
                                    :uniforms ',uniforms
                                    :attrs ',attrs
                                    :shaders ',shaders)
@@ -83,6 +84,7 @@ the source is a list.  In this case, `KEY` is the car of that list,
                             options
                           (push `(make-instance 'program-source
                                    :name ',name
+                                   :uniform-style ',uniform-style
                                    :uniforms ',uniform-list
                                    :shaders ',shaders)
                                 programs)))))))


### PR DESCRIPTION
…ase symbols.

@rpav ,

This is needed when different GLSL DSL's generate GLSL code using camel-case names. This was made into a generic function, with the default behavior specified as the current `:underscore` method. `DEFDICT` now accepts a `:uniform-style` option, defaulting to the same behavior as before, converting lisp dashes into underscores. When `:uniform-style` is instead specified as `:camel-case`, uniforms will now try to access the GLSL code as if it were camelcase'd.

This was made into a PR instead of committing directly to master to give @rpav a chance to review these changes. He had passed over maintainer to me about a year ago, but as this is the first change that adds a new feature, I want to be sure the implementation is acceptable in his eyes.